### PR TITLE
Add `toolranks` support

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -30,4 +30,5 @@ read_globals = {
 	"frame",
 	"intllib",
 	"mg",
+	"toolranks",
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- More Ores tools now have [`toolranks`](https://github.com/lisacvuk/minetest-toolranks) support.
+
 ## [2.0.0] - 2019-11-25
 
 ### Added

--- a/init.lua
+++ b/init.lua
@@ -232,6 +232,14 @@ local function add_ore(modname, description, mineral_name, oredef)
 			end
 		end
 
+		-- Toolranks support
+		if minetest.get_modpath("toolranks") then
+			minetest.override_item(fulltool_name, {
+				original_description = tdef.description,
+				description = toolranks.create_description(tdef.description, 0, 1),
+				after_use = toolranks.new_afteruse})
+		end
+
 		minetest.register_alias(tool_name .. tool_post, fulltool_name)
 		if use_frame then
 			frame.register(fulltool_name)

--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,4 @@
 name = moreores
 description = Adds new ore types.
 depends = default
-optional_depends = carts,farming,frame,intllib,mg
+optional_depends = carts,farming,frame,intllib,mg,toolranks


### PR DESCRIPTION
Adds `toolranks` support for More Ores tools, due to support being removed from the `toolranks` mod (https://github.com/lisacvuk/minetest-toolranks/pull/7) to fix the circular dependency issues:

Closes https://github.com/minetest-mods/moreores/issues/33
https://github.com/lisacvuk/minetest-toolranks/issues/5
https://github.com/pandorabox-io/pandorabox.io/issues/389

It is also compatible with TenPlus1's fork (already has support removed): https://notabug.org/TenPlus1/toolranks