### PR TITLE
Improve ore generation to better match recent Minetest versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- [Tweaked ore generation to better fit Minetest's new defaults.](https://github.com/minetest-mods/moreores/pull/45)
+  - Three layers (two underground and one high air/space) are now used instead of just one layer.
+  - Chunk size is no longer used as clust size anymore. Clust sizes are usually
+    just 3 nodes and not the whole area ("chunk"), where the ores are generated.
+  - Adjusted several default values.
+    - Mithril is now generated *below* diamond. Note that there was a change
+      in Minetest 5.0.0 where most ore generation was shifted to much lower
+      altitude (shifting diamond generation altitude below mithril generation altitude).
+    - The mithril ores are now also grouped together and not just found as a
+      single node in one chunk.
+    - The same overall ore density is retained in the deep layer.
+
 ## [2.1.0] - 2021-06-28
 
 ### Added

--- a/_config.txt
+++ b/_config.txt
@@ -34,20 +34,22 @@ moreores.mithril_clust_size = 3
 moreores.mithril_clust_size_deep = 3
 
 -- Maximal and minimal depths of ore generation (Y coordinate, 0 being sea level by default)
---Tin
+-- Tin
 moreores.tin_max_depth = -64
 moreores.tin_min_depth = -31000
---Silver
+
+-- Silver
 moreores.silver_max_depth_high = 31000 
 moreores.silver_min_depth_high = 1025
-moreores.silver_max_depth = -64         --For v6 mapgen -32 fits better
-moreores.silver_min_depth = -127        --For v6 mapgen -63 fits better
-moreores.silver_max_depth_deep = -128   --For v6 mapgen -64 fits better
+moreores.silver_max_depth = -64         -- For v6 mapgen, -32 fits better
+moreores.silver_min_depth = -127        -- For v6 mapgen, -63 fits better
+moreores.silver_max_depth_deep = -128   -- For v6 mapgen, -64 fits better
 moreores.silver_min_depth_deep = -31000
---Mithril
+
+-- Mithril
 moreores.mithril_max_depth_high = 31000
 moreores.mithril_min_depth_high = 2049
-moreores.mithril_max_depth = -2048          --For v6 mapgen -256 fits better
-moreores.mithril_min_depth = -4095          --For v6 mapgen -511 fits better
-moreores.mithril_max_depth_deep = -4096     --For v6 mapgen -512 fits better
+moreores.mithril_max_depth = -2048          -- For v6 mapgen, -256 fits better
+moreores.mithril_min_depth = -4095          -- For v6 mapgen, -511 fits better
+moreores.mithril_max_depth_deep = -4096     -- For v6 mapgen, -512 fits better
 moreores.mithril_min_depth_deep = -31000

--- a/_config.txt
+++ b/_config.txt
@@ -38,7 +38,7 @@ moreores.mithril_clust_size_deep = 3
 moreores.tin_max_depth = -64
 moreores.tin_min_depth = -31000
 --Silver
-moreores.silver_max_depth_high = 31000 
+moreores.silver_max_depth_high = 31000
 moreores.silver_min_depth_high = 1025
 moreores.silver_max_depth = -64         --For v6 mapgen -32 fits better
 moreores.silver_min_depth = -127        --For v6 mapgen -63 fits better

--- a/_config.txt
+++ b/_config.txt
@@ -7,21 +7,47 @@
 ------------------------------------------------------------------------------
 
 -- Chunk sizes for ore generation (bigger = ore deposits are more scattered around)
-moreores.tin_chunk_size = 7
-moreores.silver_chunk_size = 11
-moreores.mithril_chunk_size = 11
+moreores.tin_chunk_size = 10
+moreores.silver_chunk_size_high = 11
+moreores.silver_chunk_size = 13
+moreores.silver_chunk_size_deep = 11
+moreores.mithril_chunk_size_high = 17
+moreores.mithril_chunk_size = 21
+moreores.mithril_chunk_size_deep = 21
 
 -- Amount of ore per chunk (higher = bigger ore deposits)
-moreores.tin_ore_per_chunk = 3
-moreores.silver_ore_per_chunk = 4
-moreores.mithril_ore_per_chunk = 1
+moreores.tin_ore_per_chunk = 5
+moreores.silver_ore_per_chunk_high = 4
+moreores.silver_ore_per_chunk = 2
+moreores.silver_ore_per_chunk_deep = 4
+moreores.mithril_ore_per_chunk_high = 3
+moreores.mithril_ore_per_chunk = 3
+moreores.mithril_ore_per_chunk_deep = 7
 
--- Minimal depths of ore generation (Y coordinate, 0 being sea level by default)
+-- Clust sizes for ore generation (bigger = ores in ore deposits are less bound together)
+moreores.tin_clust_size = 3
+moreores.silver_clust_size_high = 3
+moreores.silver_clust_size = 3
+moreores.silver_clust_size_deep = 3
+moreores.mithril_clust_size_high = 3
+moreores.mithril_clust_size = 3
+moreores.mithril_clust_size_deep = 4
+
+-- Maximal and minimal depths of ore generation (Y coordinate, 0 being sea level by default)
+--Tin
+moreores.tin_max_depth = -64
 moreores.tin_min_depth = -31000
-moreores.silver_min_depth = -31000
-moreores.mithril_min_depth = -31000
-
--- Maximal depths of ore generation (Y coordinate, 0 being sea level by default)
-moreores.tin_max_depth = 8
-moreores.silver_max_depth = -2
-moreores.mithril_max_depth = -512
+--Silver
+moreores.silver_max_depth_high = 31000 
+moreores.silver_min_depth_high = 1025
+moreores.silver_max_depth = -64         --For v6 mapgen -32 fits better
+moreores.silver_min_depth = -127        --For v6 mapgen -63 fits better
+moreores.silver_max_depth_deep = -128   --For v6 mapgen -64 fits better
+moreores.silver_min_depth_deep = -31000
+--Mithril
+moreores.mithril_max_depth_high = 31000
+moreores.mithril_min_depth_high = 2049
+moreores.mithril_max_depth = -2048          --For v6 mapgen -256 fits better
+moreores.mithril_min_depth = -4095          --For v6 mapgen -511 fits better
+moreores.mithril_max_depth_deep = -4096     --For v6 mapgen -512 fits better
+moreores.mithril_min_depth_deep = -31000

--- a/_config.txt
+++ b/_config.txt
@@ -7,39 +7,64 @@
 ------------------------------------------------------------------------------
 
 -- Chunk sizes for ore generation (bigger = ore deposits are more scattered around)
-moreores.tin_chunk_size = 10
+-- Tin
+moreores.tin_chunk_size_high = 10
+moreores.tin_chunk_size = 13
+moreores.tin_chunk_size_deep = 10
+
+-- Silver
 moreores.silver_chunk_size_high = 11
 moreores.silver_chunk_size = 13
 moreores.silver_chunk_size_deep = 11
+
+-- Mithril
 moreores.mithril_chunk_size_high = 19
 moreores.mithril_chunk_size = 21
 moreores.mithril_chunk_size_deep = 19
 
 -- Amount of ore per chunk (higher = bigger ore deposits)
-moreores.tin_ore_per_chunk = 5
+-- Tin
+moreores.tin_ore_per_chunk_high = 5
+moreores.tin_ore_per_chunk = 4
+moreores.tin_ore_per_chunk_deep = 5
+
+-- Silver
 moreores.silver_ore_per_chunk_high = 4
 moreores.silver_ore_per_chunk = 2
 moreores.silver_ore_per_chunk_deep = 4
+
+-- Mithril
 moreores.mithril_ore_per_chunk_high = 3
 moreores.mithril_ore_per_chunk = 2
 moreores.mithril_ore_per_chunk_deep = 4
 
 -- Clust sizes for ore generation (bigger = ores in ore deposits are less bound together)
+-- Tin
+moreores.tin_clust_size_high = 3
 moreores.tin_clust_size = 3
+moreores.tin_clust_size_deep = 3
+
+-- Silver
 moreores.silver_clust_size_high = 3
 moreores.silver_clust_size = 3
 moreores.silver_clust_size_deep = 3
+
+-- Mithril
 moreores.mithril_clust_size_high = 3
 moreores.mithril_clust_size = 3
 moreores.mithril_clust_size_deep = 3
 
 -- Maximal and minimal depths of ore generation (Y coordinate, 0 being sea level by default)
 -- Tin
-moreores.tin_max_depth = -64
-moreores.tin_min_depth = -31000
+moreores.tin_max_depth_high = 31000
+moreores.tin_min_depth_high = 1025
+moreores.tin_max_depth = -64           -- For v6 mapgen, -32 fits better
+moreores.tin_min_depth = -127
+moreores.tin_max_depth_deep = -128
+moreores.tin_min_depth_deep = -31000
 
 -- Silver
-moreores.silver_max_depth_high = 31000 
+moreores.silver_max_depth_high = 31000
 moreores.silver_min_depth_high = 1025
 moreores.silver_max_depth = -64         -- For v6 mapgen, -32 fits better
 moreores.silver_min_depth = -127        -- For v6 mapgen, -63 fits better

--- a/_config.txt
+++ b/_config.txt
@@ -11,9 +11,9 @@ moreores.tin_chunk_size = 10
 moreores.silver_chunk_size_high = 11
 moreores.silver_chunk_size = 13
 moreores.silver_chunk_size_deep = 11
-moreores.mithril_chunk_size_high = 17
+moreores.mithril_chunk_size_high = 19
 moreores.mithril_chunk_size = 21
-moreores.mithril_chunk_size_deep = 21
+moreores.mithril_chunk_size_deep = 19
 
 -- Amount of ore per chunk (higher = bigger ore deposits)
 moreores.tin_ore_per_chunk = 5
@@ -21,8 +21,8 @@ moreores.silver_ore_per_chunk_high = 4
 moreores.silver_ore_per_chunk = 2
 moreores.silver_ore_per_chunk_deep = 4
 moreores.mithril_ore_per_chunk_high = 3
-moreores.mithril_ore_per_chunk = 3
-moreores.mithril_ore_per_chunk_deep = 7
+moreores.mithril_ore_per_chunk = 2
+moreores.mithril_ore_per_chunk_deep = 4
 
 -- Clust sizes for ore generation (bigger = ores in ore deposits are less bound together)
 moreores.tin_clust_size = 3
@@ -31,7 +31,7 @@ moreores.silver_clust_size = 3
 moreores.silver_clust_size_deep = 3
 moreores.mithril_clust_size_high = 3
 moreores.mithril_clust_size = 3
-moreores.mithril_clust_size_deep = 4
+moreores.mithril_clust_size_deep = 3
 
 -- Maximal and minimal depths of ore generation (Y coordinate, 0 being sea level by default)
 --Tin

--- a/init.lua
+++ b/init.lua
@@ -166,11 +166,21 @@ local function add_ore(modname, description, mineral_name, oredef)
 		})
 	end
 
+	oredef.oredef_high.ore_type = "scatter"
+	oredef.oredef_high.ore = modname .. ":mineral_" .. mineral_name
+	oredef.oredef_high.wherein = "default:stone"
+
 	oredef.oredef.ore_type = "scatter"
 	oredef.oredef.ore = modname .. ":mineral_" .. mineral_name
 	oredef.oredef.wherein = "default:stone"
 
-	minetest.register_ore(oredef.oredef)
+	oredef.oredef_deep.ore_type = "scatter"
+	oredef.oredef_deep.ore = modname .. ":mineral_" .. mineral_name
+	oredef.oredef_deep.wherein = "default:stone"
+
+	minetest.register_ore(oredef.oredef_high)
+    minetest.register_ore(oredef.oredef)
+    minetest.register_ore(oredef.oredef_deep)
 
 	for tool_name, tooldef in pairs(oredef.tools) do
 		local tdef = {
@@ -244,12 +254,26 @@ local oredefs = {
 	silver = {
 		description = "Silver",
 		makes = {ore = true, block = true, lump = true, ingot = true, chest = true},
+		oredef_high= {
+			clust_scarcity = moreores.silver_chunk_size_high ^ 3,
+			clust_num_ores = moreores.silver_ore_per_chunk_high,
+			clust_size = moreores.silver_clust_size_high,
+			y_min = moreores.silver_min_depth_high,
+			y_max = moreores.silver_max_depth_high,
+		},
 		oredef = {
 			clust_scarcity = moreores.silver_chunk_size ^ 3,
 			clust_num_ores = moreores.silver_ore_per_chunk,
-			clust_size = moreores.silver_chunk_size,
+			clust_size = moreores.silver_clust_size,
 			y_min = moreores.silver_min_depth,
 			y_max = moreores.silver_max_depth,
+		},
+		oredef_deep = {
+			clust_scarcity = moreores.silver_chunk_size_deep ^ 3,
+			clust_num_ores = moreores.silver_ore_per_chunk_deep,
+			clust_size = moreores.silver_clust_size_deep,
+			y_min = moreores.silver_min_depth_deep,
+			y_max = moreores.silver_max_depth_deep,
 		},
 		tools = {
 			pick = {
@@ -288,12 +312,26 @@ local oredefs = {
 	mithril = {
 		description = "Mithril",
 		makes = {ore = true, block = true, lump = true, ingot = true, chest = false},
+		oredef_high = {
+			clust_scarcity = moreores.mithril_chunk_size_high ^ 3,
+			clust_num_ores = moreores.mithril_ore_per_chunk_high,
+			clust_size = moreores.mithril_clust_size_high,
+			y_min = moreores.mithril_min_depth_high,
+			y_max = moreores.mithril_max_depth_high,
+		},
 		oredef = {
 			clust_scarcity = moreores.mithril_chunk_size ^ 3,
 			clust_num_ores = moreores.mithril_ore_per_chunk,
-			clust_size = moreores.mithril_chunk_size,
+			clust_size = moreores.mithril_clust_size,
 			y_min = moreores.mithril_min_depth,
 			y_max = moreores.mithril_max_depth,
+		},
+		oredef_deep = {
+			clust_scarcity = moreores.mithril_chunk_size_deep ^ 3,
+			clust_num_ores = moreores.mithril_ore_per_chunk_deep,
+			clust_size = moreores.mithril_clust_size_deep,
+			y_min = moreores.mithril_min_depth_deep,
+			y_max = moreores.mithril_max_depth_deep,
 		},
 		tools = {
 			pick = {

--- a/init.lua
+++ b/init.lua
@@ -185,25 +185,25 @@ local function add_ore(modname, description, mineral_name, oredef)
 
 		if tool_name == "sword" then
 			tdef.tool_capabilities.full_punch_interval = oredef.full_punch_interval
-			tdef.tool_capabilities.damage_groups = oredef.damage_groups
+			tdef.tool_capabilities.damage_groups = oredef.tools.sword.damage_groups
 			tdef.description = S("@1 Sword", S(description))
 		end
 
 		if tool_name == "pick" then
 			tdef.tool_capabilities.full_punch_interval = oredef.full_punch_interval
-			tdef.tool_capabilities.damage_groups = oredef.damage_groups
+			tdef.tool_capabilities.damage_groups = oredef.tools.pick.damage_groups
 			tdef.description = S("@1 Pickaxe", S(description))
 		end
 
 		if tool_name == "axe" then
 			tdef.tool_capabilities.full_punch_interval = oredef.full_punch_interval
-			tdef.tool_capabilities.damage_groups = oredef.damage_groups
+			tdef.tool_capabilities.damage_groups = oredef.tools.axe.damage_groups
 			tdef.description = S("@1 Axe", S(description))
 		end
 
 		if tool_name == "shovel" then
 			tdef.full_punch_interval = oredef.full_punch_interval
-			tdef.tool_capabilities.damage_groups = oredef.damage_groups
+			tdef.tool_capabilities.damage_groups = oredef.tools.shovel.damage_groups
 			tdef.description = S("@1 Shovel", S(description))
 			tdef.wield_image = toolimg_base .. tool_name .. ".png^[transformR90"
 		end
@@ -260,25 +260,28 @@ local oredefs = {
 		tools = {
 			pick = {
 				cracky = {times = {[1] = 2.60, [2] = 1.00, [3] = 0.60}, uses = 100, maxlevel = 1},
+                damage_groups = {fleshy = 4},
 			},
 			hoe = {
 				uses = 300,
 			},
 			shovel = {
 				crumbly = {times = {[1] = 1.10, [2] = 0.40, [3] = 0.25}, uses = 100, maxlevel = 1},
+                damage_groups = {fleshy = 3},
 			},
 			axe = {
 				choppy = {times = {[1] = 2.50, [2] = 0.80, [3] = 0.50}, uses = 100, maxlevel = 1},
-				fleshy = {times = {[2] = 1.10, [3] = 0.60}, uses = 100, maxlevel = 1}
+				fleshy = {times = {[2] = 1.10, [3] = 0.60}, uses = 100, maxlevel = 1},
+                damage_groups = {fleshy = 5},
 			},
 			sword = {
 				fleshy = {times = {[2] = 0.70, [3] = 0.30}, uses = 100, maxlevel = 1},
-				snappy = {times = {[2] = 0.70, [3] = 0.30}, uses = 100, maxlevel = 1},
+				snappy = {times = {[1] = 1.70, [2] = 0.70, [3] = 0.30}, uses = 100, maxlevel = 1},
 				choppy = {times = {[3] = 0.80}, uses = 100, maxlevel = 0},
+                damage_groups = {fleshy = 6},
 			},
 		},
 		full_punch_interval = 1.0,
-		damage_groups = {fleshy = 6},
 	},
 	mithril = {
 		description = "Mithril",
@@ -292,26 +295,29 @@ local oredefs = {
 		},
 		tools = {
 			pick = {
-				cracky = {times = {[1] = 2.25, [2] = 0.55, [3] = 0.35}, uses = 200, maxlevel = 2}
+				cracky = {times = {[1] = 2.25, [2] = 0.55, [3] = 0.35}, uses = 200, maxlevel = 3},
+                damage_groups = {fleshy = 6},
 			},
 			hoe = {
 				uses = 1000,
 			},
 			shovel = {
-				crumbly = {times = {[1] = 0.70, [2] = 0.35, [3] = 0.20}, uses = 200, maxlevel = 2},
+				crumbly = {times = {[1] = 0.70, [2] = 0.35, [3] = 0.20}, uses = 200, maxlevel = 3},
+                damage_groups = {fleshy = 5},
 			},
 			axe = {
-				choppy = {times = {[1] = 1.75, [2] = 0.45, [3] = 0.45}, uses = 200, maxlevel = 2},
-				fleshy = {times = {[2] = 0.95, [3] = 0.30}, uses = 200, maxlevel = 1}
+				choppy = {times = {[1] = 1.75, [2] = 0.45, [3] = 0.45}, uses = 200, maxlevel = 3},
+				fleshy = {times = {[2] = 0.95, [3] = 0.30}, uses = 200, maxlevel = 2},
+                damage_groups = {fleshy = 8},
 			},
 			sword = {
 				fleshy = {times = {[2] = 0.65, [3] = 0.25}, uses = 200, maxlevel = 2},
-				snappy = {times = {[2] = 0.70, [3] = 0.25}, uses = 200, maxlevel = 2},
+				snappy = {times = {[1] = 1.70, [2] = 0.70, [3] = 0.25}, uses = 200, maxlevel = 3},
 				choppy = {times = {[3] = 0.65}, uses = 200, maxlevel = 0},
+                damage_groups = {fleshy = 10},
 			},
 		},
 		full_punch_interval = 0.45,
-		damage_groups = {fleshy = 9},
 	}
 }
 

--- a/init.lua
+++ b/init.lua
@@ -260,25 +260,25 @@ local oredefs = {
 		tools = {
 			pick = {
 				cracky = {times = {[1] = 2.60, [2] = 1.00, [3] = 0.60}, uses = 100, maxlevel = 1},
-			damage_groups = {fleshy = 4},
+				damage_groups = {fleshy = 4},
 			},
 			hoe = {
 				uses = 300,
 			},
 			shovel = {
 				crumbly = {times = {[1] = 1.10, [2] = 0.40, [3] = 0.25}, uses = 100, maxlevel = 1},
-			damage_groups = {fleshy = 3},
+				damage_groups = {fleshy = 3},
 			},
 			axe = {
 				choppy = {times = {[1] = 2.50, [2] = 0.80, [3] = 0.50}, uses = 100, maxlevel = 1},
 				fleshy = {times = {[2] = 1.10, [3] = 0.60}, uses = 100, maxlevel = 1},
-			damage_groups = {fleshy = 5},
+				damage_groups = {fleshy = 5},
 			},
 			sword = {
 				fleshy = {times = {[2] = 0.70, [3] = 0.30}, uses = 100, maxlevel = 1},
 				snappy = {times = {[1] = 1.70, [2] = 0.70, [3] = 0.30}, uses = 100, maxlevel = 1},
 				choppy = {times = {[3] = 0.80}, uses = 100, maxlevel = 0},
-			damage_groups = {fleshy = 6},
+				damage_groups = {fleshy = 6},
 			},
 		},
 		full_punch_interval = 1.0,
@@ -296,25 +296,25 @@ local oredefs = {
 		tools = {
 			pick = {
 				cracky = {times = {[1] = 2.25, [2] = 0.55, [3] = 0.35}, uses = 200, maxlevel = 3},
-			damage_groups = {fleshy = 6},
+				damage_groups = {fleshy = 6},
 			},
 			hoe = {
 				uses = 1000,
 			},
 			shovel = {
 				crumbly = {times = {[1] = 0.70, [2] = 0.35, [3] = 0.20}, uses = 200, maxlevel = 3},
-			damage_groups = {fleshy = 5},
+				damage_groups = {fleshy = 5},
 			},
 			axe = {
 				choppy = {times = {[1] = 1.75, [2] = 0.45, [3] = 0.45}, uses = 200, maxlevel = 3},
 				fleshy = {times = {[2] = 0.95, [3] = 0.30}, uses = 200, maxlevel = 2},
-			damage_groups = {fleshy = 8},
+				damage_groups = {fleshy = 8},
 			},
 			sword = {
 				fleshy = {times = {[2] = 0.65, [3] = 0.25}, uses = 200, maxlevel = 2},
 				snappy = {times = {[1] = 1.70, [2] = 0.70, [3] = 0.25}, uses = 200, maxlevel = 3},
 				choppy = {times = {[3] = 0.65}, uses = 200, maxlevel = 0},
-			damage_groups = {fleshy = 10},
+				damage_groups = {fleshy = 10},
 			},
 		},
 		full_punch_interval = 0.45,

--- a/init.lua
+++ b/init.lua
@@ -179,8 +179,8 @@ local function add_ore(modname, description, mineral_name, oredef)
 	oredef.oredef_deep.wherein = "default:stone"
 
 	minetest.register_ore(oredef.oredef_high)
-    minetest.register_ore(oredef.oredef)
-    minetest.register_ore(oredef.oredef_deep)
+	minetest.register_ore(oredef.oredef)
+	minetest.register_ore(oredef.oredef_deep)
 
 	for tool_name, tooldef in pairs(oredef.tools) do
 		local tdef = {

--- a/init.lua
+++ b/init.lua
@@ -386,12 +386,26 @@ else
 	oredefs.tin = {
 		description = "Tin",
 		makes = {ore = true, block = true, lump = true, ingot = true, chest = false},
+		oredef_high = {
+			clust_scarcity = moreores.tin_chunk_size_high ^ 3,
+			clust_num_ores = moreores.tin_ore_per_chunk_high,
+			clust_size = moreores.tin_clust_size_high,
+			y_min = moreores.tin_min_depth_high,
+			y_max = moreores.tin_max_depth_high,
+		},
 		oredef = {
 			clust_scarcity = moreores.tin_chunk_size ^ 3,
 			clust_num_ores = moreores.tin_ore_per_chunk,
-			clust_size = moreores.tin_chunk_size,
+			clust_size = moreores.tin_clust_size,
 			y_min = moreores.tin_min_depth,
 			y_max = moreores.tin_max_depth,
+		},
+		oredef_deep = {
+			clust_scarcity = moreores.tin_chunk_size_deep ^ 3,
+			clust_num_ores = moreores.tin_ore_per_chunk_deep,
+			clust_size = moreores.tin_clust_size_deep,
+			y_min = moreores.tin_min_depth_deep,
+			y_max = moreores.tin_max_depth_deep,
 		},
 		tools = {},
 	}

--- a/init.lua
+++ b/init.lua
@@ -260,25 +260,25 @@ local oredefs = {
 		tools = {
 			pick = {
 				cracky = {times = {[1] = 2.60, [2] = 1.00, [3] = 0.60}, uses = 100, maxlevel = 1},
-                damage_groups = {fleshy = 4},
+			damage_groups = {fleshy = 4},
 			},
 			hoe = {
 				uses = 300,
 			},
 			shovel = {
 				crumbly = {times = {[1] = 1.10, [2] = 0.40, [3] = 0.25}, uses = 100, maxlevel = 1},
-                damage_groups = {fleshy = 3},
+			damage_groups = {fleshy = 3},
 			},
 			axe = {
 				choppy = {times = {[1] = 2.50, [2] = 0.80, [3] = 0.50}, uses = 100, maxlevel = 1},
 				fleshy = {times = {[2] = 1.10, [3] = 0.60}, uses = 100, maxlevel = 1},
-                damage_groups = {fleshy = 5},
+			damage_groups = {fleshy = 5},
 			},
 			sword = {
 				fleshy = {times = {[2] = 0.70, [3] = 0.30}, uses = 100, maxlevel = 1},
 				snappy = {times = {[1] = 1.70, [2] = 0.70, [3] = 0.30}, uses = 100, maxlevel = 1},
 				choppy = {times = {[3] = 0.80}, uses = 100, maxlevel = 0},
-                damage_groups = {fleshy = 6},
+			damage_groups = {fleshy = 6},
 			},
 		},
 		full_punch_interval = 1.0,
@@ -296,25 +296,25 @@ local oredefs = {
 		tools = {
 			pick = {
 				cracky = {times = {[1] = 2.25, [2] = 0.55, [3] = 0.35}, uses = 200, maxlevel = 3},
-                damage_groups = {fleshy = 6},
+			damage_groups = {fleshy = 6},
 			},
 			hoe = {
 				uses = 1000,
 			},
 			shovel = {
 				crumbly = {times = {[1] = 0.70, [2] = 0.35, [3] = 0.20}, uses = 200, maxlevel = 3},
-                damage_groups = {fleshy = 5},
+			damage_groups = {fleshy = 5},
 			},
 			axe = {
 				choppy = {times = {[1] = 1.75, [2] = 0.45, [3] = 0.45}, uses = 200, maxlevel = 3},
 				fleshy = {times = {[2] = 0.95, [3] = 0.30}, uses = 200, maxlevel = 2},
-                damage_groups = {fleshy = 8},
+			damage_groups = {fleshy = 8},
 			},
 			sword = {
 				fleshy = {times = {[2] = 0.65, [3] = 0.25}, uses = 200, maxlevel = 2},
 				snappy = {times = {[1] = 1.70, [2] = 0.70, [3] = 0.25}, uses = 200, maxlevel = 3},
 				choppy = {times = {[3] = 0.65}, uses = 200, maxlevel = 0},
-                damage_groups = {fleshy = 10},
+			damage_groups = {fleshy = 10},
 			},
 		},
 		full_punch_interval = 0.45,


### PR DESCRIPTION
This fits the moreores ore generation to the default ore generation.
1. Three layers (two underground and one high air/ space) instead of just one layer.
2. Don't use chunk size as clust size anymore. Clust sizes are usually just 3 nodes and not the whole area ("chunk"), where the ores are generated.
3. Adjust more default values.
3.1. Mithril is now generated below diamond (!). Note that there was a change in the minetest update 5.0.0, where most ore generation was shifted to much lower altitude (shifting diamond generation altitude below mithril generation altitude). 
3.2. The mithril ores are now also grouped together and not just found as a single node in one chunk.
3.3. I tried to retain the same overall ore density (for the deep layer).

