### PR TITLE
Create crafting recipe for hoes

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -216,6 +216,7 @@ local function add_ore(modname, description, mineral_name, oredef)
 
 		if tool_name == "hoe" and minetest.get_modpath("farming") then
 			tdef.max_uses = tooldef.max_uses
+			tdef.material = ingot
 			tdef.description = S("@1 Hoe", S(description))
 			farming.register_hoe(fulltool_name, tdef)
 		end


### PR DESCRIPTION
`register_hoe` needs either a recipe or a material to register a crafting recipe. This passes in a material.

https://notabug.org/TenPlus1/farming/src/962bb6aeff91b4307dec257ffb0061cb9af244fe/hoes.lua#L48