### PR TITLE
fixing default_stone_sounds warnings

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -3,11 +3,6 @@ unused_args = false
 allow_defined_top = true
 max_line_length = 90
 
-ignore = {
-  "default_stone_sounds",
-	"default_metal_sounds"
-}
-
 stds.minetest = {
 	read_globals = {
 		"DIR_DELIM",

--- a/init.lua
+++ b/init.lua
@@ -33,12 +33,15 @@ local stone_ingredient = is_mcl_core_present and "mcl_core:stone" or "default:st
 local copper_ingredient =
 is_mcl_core_present and "mcl_copper:copper_ingot" or 'default:copper_ingot'
 
+local default_stone_sounds
+local default_metal_sounds
+
 if is_mcl_sounds_present then
-local default_stone_sounds = mcl_sounds.node_sound_stone_defaults()
-local default_metal_sounds = mcl_sounds.node_sound_metal_defaults()
+	default_stone_sounds = mcl_sounds.node_sound_stone_defaults()
+	default_metal_sounds = mcl_sounds.node_sound_metal_defaults()
 else
-local default_stone_sounds = default.node_sound_stone_defaults()
-local default_metal_sounds = default.node_sound_metal_defaults()
+	default_stone_sounds = default.node_sound_stone_defaults()
+	default_metal_sounds = default.node_sound_metal_defaults()
 end
 
 


### PR DESCRIPTION
up until this point I got messages like
<WARNING> 2024-04-04 01:04:37: [Main] Undeclared global variable "default_stone_sounds" accessed at .../moreores/init.lua:129

this PR fixes that
further explanation: https://onecompiler.com/lua/4298qx5jk